### PR TITLE
Fixed disappearing events on bucket issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,17 +166,7 @@ module.exports = function(S) {
             return _this.aws.request('S3', 'deleteObjects', params, _this.evt.options.stage, _this.evt.options.region)
           }})
         .then(function(){
-          if (!_this.bucketExists) return BbPromise.resolve();
-
-          S.utils.sDebug(`Deleting bucket ${_this.bucketName}...`);
-
-          let params = {
-            Bucket: _this.bucketName
-          };
-          return _this.aws.request('S3', 'deleteBucket', params, _this.evt.options.stage, _this.evt.options.region)
-        })
-        .then(function(){
-
+          if (_this.bucketExists) return BbPromise.resolve();
           S.utils.sDebug(`Creating bucket ${_this.bucketName}...`);
 
           let params = {


### PR DESCRIPTION
Change so that the bucket isn't removed and re-created. instead the bucket content is removed and new is added. If the bucket exists, it will not be created. 
