### PR TITLE
Fixes deployment of dist subfolders from Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ module.exports = function(S) {
 
     _uploadFile(filePath) {
       let _this      = this,
-        fileKey    = filePath.replace(_this.clientPath, '').substr(1);
+          fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace('\\', '/');
 
       S.utils.sDebug(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
 


### PR DESCRIPTION
This PR closes serverless/serverless-client-s3#16.
As mentioned [here](https://github.com/serverless/serverless-client-s3/issues/16) on Windows the deployment of subfolders in the dist folder does not work properly.
