### PR TITLE
replace all slashes, not just first occurance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ module.exports = function(S) {
 
     _uploadFile(filePath) {
       let _this      = this,
-          fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace('\\', '/');
+          fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace(/\\/g, '/');
 
       S.utils.sDebug(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
 


### PR DESCRIPTION
The replace should replace all instances of a back-slash in the uploaded filename, not just the first.

The original issue is only reproducible on Windows.
