### PR TITLE
Allow a developer to remove the 'prod' stage text from bucket name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ npm install --save serverless-client-s3
 * **Warning:** The plugin will overwrite any data you have in the bucket name you set above if it already exists.
 * **Pro Tip:** To add staging and region functionality to your client, use Serverless Variables in the bucket name: `"bucket.name.for.the.client.${stage}.${region}"`
 
+* **Side Note** When hosting a client with a domain name, the bucket name must have exactly the same name as the domain. For this reason you may also optionally specify a regular expression to be replaced in your bucket name to remove, for instance, "prod." from the start of your bucket name:
+
+```js
+    "bucketName":"${stage}.my.example.com",
+    "removeBucketRegex":"^prod\\.""
+```
 
 **Third**, Create a `client/dist` folder in the root directory of your Serverless project. This is where your distribution-ready website should live. It is recommended to have a `client/src` where you'll be developing your website, and a build script that outputs to `client/dist`. The plugin simply expects and uploads the entire `client/dist` folder to S3, configure the bucket to host the website, and make it publicly available.
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,8 @@ module.exports = function(S) {
         return BbPromise.reject(new SError('Please specify a bucket name for the client in s-project.json'));
       }
 
-      _this.bucketName = populatedProject.custom.client.bucketName;
+      var removalRegex = new RegExp(populatedProject.custom.client.removeBucketRegex,"g");
+      _this.bucketName = populatedProject.custom.client.bucketName.replace(removalRegex,'');
       _this.clientPath = path.join(_this.project.getRootPath(), 'client', 'dist');
 
       return BbPromise.resolve();


### PR DESCRIPTION
Having a stage name for test, dev, UAT, etc is great, but when you host a project using a CNAME domain for a nice project URL, the bucket name **must match that domain name exactly**.

Allowing the user to optionally specify a regex string removal of the (e.g.) prod stage name from the bucket name allows the developer to push the prod stage so the bucket name matches the client project's domain name, while still allowing dev, test, uat, etc. s3 endpoints.
## Example

``` bash
CartesiCreative:node_modules duncanjm$ sls client deploy -s dev
Serverless: Deploying client to stage "dev" in region "us-east-1"...  
Serverless: Finishing deployment...  
Serverless: Successfully deployed client to: dev.augrel.cartesive.com.s3-website-us-east-1.amazonaws.com  
1.amazonaws.com  
CartesiCreative:node_modules duncanjm$ sls client deploy -s prod
Serverless: Deploying client to stage "prod" in region "us-east-1"...  
Serverless: Finishing deployment...  
Serverless: Successfully deployed client to: augrel.cartesive.com.s3-website-us-east-1.amazonaws.com  

```

Now the user can go to dev at: http://dev.augrel.cartesive.com.s3-website-us-east-1.amazonaws.com

But also prod which EXACTLY matches the domain with CNAME forwarding:

http://augrel.cartesive.com
