### PR TITLE
Bugfix: Replace all the backslashes, not just the first.

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ module.exports = function(S) {
 
     _uploadFile(filePath) {
       let _this      = this,
-          fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace('\\', '/');
+          fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace(/\\/g, '/');
 
       S.utils.sDebug(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
 


### PR DESCRIPTION
The prior attempt at this bugfix used string.replace(str, str), which just replaces the first instance. Switched to using a regex replace so that it would replace globally.
