### PR TITLE
Feature: simple caching via expires header

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ module.exports = function(S) {
     }
     
     _isHash(name) {
-      return (/^[a-f0-9]{32}$/).test(name) && (/[a-f].*[a-f]/).test(name) && (/[0-9].*[0-9]/).test(name);
+      return (/^[a-f0-9]{20,32}$/).test(name) && (/[a-f].*[a-f]/).test(name) && (/[0-9].*[0-9]/).test(name);
     }
 
   }

--- a/index.js
+++ b/index.js
@@ -251,13 +251,27 @@ module.exports = function(S) {
           Bucket: _this.bucketName,
           Key: fileKey,
           Body: fileBuffer,
-          ContentType: mime.lookup(filePath)
+          ContentType: mime.lookup(filePath),
+          Expires: _cacheDuration(filePath),
         };
 
-        // TODO: remove browser caching
         return _this.aws.request('S3', 'putObject', params, _this.evt.options.stage, _this.evt.options.region)
       });
 
+    }
+    
+    _cacheDuration(filePath) {
+      const CACHE_BRIEFLY = 60,
+          CACHE_FOREVER = 315576000; // 10 years
+		  let fileParts = path.basename(filePath).split('.');
+		  if (fileParts.length < 3) return CACHE_BRIEFLY;
+		  return (_isHash(fileParts[fileParts.length - 2]))
+		    ? CACHE_FOREVER
+		    : CACHE BRIEFLY;
+    }
+    
+    _isHash(name) {
+      return (/^[a-f0-9]{32}$/).test(name) && (/[a-f].*[a-f]/).test(name) && (/[0-9].*[0-9]/).test(name);
     }
 
   }

--- a/index.js
+++ b/index.js
@@ -252,24 +252,24 @@ module.exports = function(S) {
           Key: fileKey,
           Body: fileBuffer,
           ContentType: mime.lookup(filePath),
-          Expires: _cacheDuration(filePath),
+          Expires: _this._cacheDuration(filePath),
         };
 
         return _this.aws.request('S3', 'putObject', params, _this.evt.options.stage, _this.evt.options.region)
       });
 
     }
-    
+
     _cacheDuration(filePath) {
       const CACHE_BRIEFLY = 60,
           CACHE_FOREVER = 315576000; // 10 years
 		  let fileParts = path.basename(filePath).split('.');
 		  if (fileParts.length < 3) return CACHE_BRIEFLY;
-		  return (_isHash(fileParts[fileParts.length - 2]))
+		  return (this._isHash(fileParts[fileParts.length - 2]))
 		    ? CACHE_FOREVER
-		    : CACHE BRIEFLY;
+		    : CACHE_BRIEFLY;
     }
-    
+
     _isHash(name) {
       return (/^[a-f0-9]{20,32}$/).test(name) && (/[a-f].*[a-f]/).test(name) && (/[0-9].*[0-9]/).test(name);
     }


### PR DESCRIPTION
Computes a reasonable expires header for caching: 1 minute if there is no cache busting as part of the filename, 10 years if there is. Currently only supports cache busting by adding a hash to the filename right before the extension.
