### PR TITLE
Serverless 1.0 beta compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,17 @@ A Serverless plugin that deploys a web client for your Serverless project to an 
 ```
 npm install --save serverless-client-s3
 ```
-**Second**, update `s-project.json` by adding the following:
+**Second**, update `serverless.yml` by adding the following:
 
-```js
-"plugins": [
-  "serverless-client-s3"
-],
-"custom" : {
-    "client": {
-        "bucketName": "bucket.name.for.the.client"
-    }
-}
+```yaml
+plugins:
+  - serverless-client-s3
+ custom:
+   client:
+     bucketName: whatsbertdoing-client
 ```
 
 * **Warning:** The plugin will overwrite any data you have in the bucket name you set above if it already exists.
-* **Pro Tip:** To add staging and region functionality to your client, use Serverless Variables in the bucket name: `"bucket.name.for.the.client.${stage}.${region}"`
 
 
 **Third**, Create a `client/dist` folder in the root directory of your Serverless project. This is where your distribution-ready website should live. It is recommended to have a `client/src` where you'll be developing your website, and a build script that outputs to `client/dist`. The plugin simply expects and uploads the entire `client/dist` folder to S3, configure the bucket to host the website, and make it publicly available.
@@ -47,7 +43,7 @@ echo "error page" >> client/dist/error.html
 **Fourth**, run the plugin, and visit your new website!
 
 ```
-sls client deploy
+serverless client deploy
 ```
 
 **Fifth**, Have fun!

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plugins:
   - serverless-client-s3
  custom:
    client:
-     bucketName: whatsbertdoing-client
+     bucketName: serverless-client-bucketname
 ```
 
 * **Warning:** The plugin will overwrite any data you have in the bucket name you set above if it already exists.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ echo "error page" >> client/dist/error.html
 **Fourth**, run the plugin, and visit your new website!
 
 ```
-serverless client deploy
+serverless client deploy [--stage $STAGE] [--region $REGION]
 ```
 
 **Fifth**, Have fun!

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ class Client {
   constructor(serverless, options){
     this.serverless = serverless;
     this.options = options;
+    this.SDK = new AWS(this.serverless);
     
     this.commands = {
       client: {
@@ -70,7 +71,6 @@ class Client {
 
  
   _processDeployment() {
-    const SDK = new AWS(this.serverless);    
     this.serverless.cli.log('Deploying client to stage "' + this.options.stage + '" in region "' + this.options.region + '"...');
 
 
@@ -80,7 +80,7 @@ class Client {
           this.bucketExists = true;
           this.serverless.cli.log(`Bucket ${this.bucketName} already exists`);
         }
-      });
+      }.bind(this));
     }
 
     function listObjectsInBucket() {
@@ -91,7 +91,7 @@ class Client {
       let params = {
         Bucket: this.bucketName
       };
-      return SDK.request('S3', 'listObjects', params, this.options.stage, this.options.region);
+      return this.SDK.request('S3', 'listObjects', params, this.options.stage, this.options.region);
     }
 
     function deleteObjectsFromBucket(data) {
@@ -111,7 +111,7 @@ class Client {
           Delete: { Objects: Objects }
         };
         
-        return _SDK.request('S3', 'deleteObjects', params, _this.options.stage, _this.options.region)
+        return _this.SDK.request('S3', 'deleteObjects', params, _this.options.stage, _this.options.region)
       }
     }
 
@@ -123,7 +123,7 @@ class Client {
         Bucket: this.bucketName
       };
       
-      return SDK.request('S3', 'createBucket', params, this.options.stage, this.options.region)
+      return this.SDK.request('S3', 'createBucket', params, this.options.stage, this.options.region)
     }
 
     function configureBucket() {
@@ -137,7 +137,7 @@ class Client {
         }
       };
       
-      return SDK.request('S3', 'putBucketWebsite', params, this.options.stage, this.options.region)
+      return this.SDK.request('S3', 'putBucketWebsite', params, this.options.stage, this.options.region)
     }
 
     function configurePolicyForBucket(){
@@ -164,10 +164,10 @@ class Client {
         Policy: JSON.stringify(policy)
       };
       
-      return SDK.request('S3', 'putBucketPolicy', params, this.options.stage, this.evt.options.region)
+      return this.SDK.request('S3', 'putBucketPolicy', params, this.options.stage, this.options.region);
     }
  
-    return SDK.request('S3', 'listBuckets', {}, this.options.stage, this.options.region)
+    return this.SDK.request('S3', 'listBuckets', {}, this.options.stage, this.options.region)
       .bind(this)
       .then(listBuckets)
       .then(listObjectsInBucket)
@@ -182,7 +182,7 @@ class Client {
 
   _uploadDirectory(directoryPath) {
     let _this         = this,
-        readDirectory = _.partial(fs.readdir, directoryPath);
+    readDirectory = _.partial(fs.readdir, directoryPath);
 
     async.waterfall([readDirectory, function (files) {
       files = _.map(files, function(file) {
@@ -198,276 +198,7 @@ class Client {
         }, _this));
       });
     }]);
-
-  }  
-
+  }
 }
 
 module.exports = Client;
-
-
-
-
-
-
-
-
-
-
-
-
-const cool =  function(S) {
-  const path     = require('path'),
-    SError       = require(S.getServerlessPath('Error')),
-    SCli         = require(S.getServerlessPath('utils/cli')),
-    BbPromise    = require('bluebird'),
-    async        = require('async'),
-    _            = require('lodash'),
-    mime         = require('mime'),
-    fs           = require('fs');
-
-  class ClientDeploy extends S.classes.Plugin {
-
-    constructor() {
-      super();
-      this.name = 'serverless-client-s3';
-    }
-
-    registerActions() {
-      S.addAction(this.clientDeploy.bind(this), {
-        handler:       'clientDeploy',
-        description:   `Deploy your Serverless clients to S3 Website Bucket.`,
-        context:       'client',
-        contextAction: 'deploy',
-        options:       [
-          {
-            option:      'stage',
-            shortcut:    's',
-            description: 'stage to populate any variables'
-          }, {
-            option:      'region',
-            shortcut:    'r',
-            description: 'region to populate any variables'
-          }
-        ]
-      });
-      return BbPromise.resolve();
-    }
-
-    clientDeploy(evt) {
-
-      let _this     = this;
-      _this.evt     = evt;
-
-      // Flow
-      return _this._prompt()
-        .bind(_this)
-        .then(_this._validateAndPrepare)
-        .then(_this._processDeployment)
-        .then(function() {
-
-          _this._spinner.stop(true);
-          SCli.log(`Finishing deployment...`);
-
-          // display friendly message after all async operations (file uploads) are finished
-          process.on('exit', function (){
-            SCli.log(`Successfully deployed client to: ${_this.bucketName}.s3-website-${_this.evt.options.region}.amazonaws.com`);
-          });
-
-          return _this.evt;
-
-        });
-
-    }
-
-
-    _prompt() {
-
-      let _this = this;
-
-      return this.cliPromptSelectStage('Client Deployer - Choose stage: ', this.evt.options.stage, false)
-          .then(stage => this.evt.options.stage = stage)
-          .then(() => this.cliPromptSelectRegion('Choose a Region in this Stage: ', false, true, _this.evt.options.region, _this.evt.options.stage))
-          .then(region => this.evt.options.region = region);
-
-    }
-
-
-    _validateAndPrepare() {
-
-      let _this = this;
-
-      if (!S.utils.dirExistsSync(path.join(S.config.projectPath, 'client', 'dist'))) {
-        return BbPromise.reject(new SError('Could not find "client/dist" folder in your project root.'));
-      }
-
-      // validate stage: make sure stage exists
-      if (!S.getProject().validateStageExists(_this.evt.options.stage)) {
-        return BbPromise.reject(new SError('Stage ' + _this.evt.options.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
-      }
-
-      // make sure region exists in stage
-      if (!S.getProject().validateRegionExists(_this.evt.options.stage, _this.evt.options.region)) {
-        return BbPromise.reject(new SError('Region "' + _this.evt.options.region + '" does not exist in stage "' + _this.evt.options.stage + '"'));
-      }
-
-      _this.project    = S.getProject();
-      _this.aws        = S.getProvider('aws');
-
-      let populatedProject = _this.project.toObjectPopulated({stage: _this.evt.options.stage, region: _this.evt.options.region});
-
-      if (!populatedProject.custom.client || !populatedProject.custom.client.bucketName) {
-        return BbPromise.reject(new SError('Please specify a bucket name for the client in s-project.json'));
-      }
-
-      _this.bucketName = populatedProject.custom.client.bucketName;
-      _this.clientPath = path.join(_this.project.getRootPath(), 'client', 'dist');
-
-      return BbPromise.resolve();
-    }
-
-    _processDeployment() {
-
-      let _this = this;
-
-      SCli.log('Deploying client to stage "' + _this.evt.options.stage + '" in region "' + _this.evt.options.region + '"...');
-
-      _this._spinner = SCli.spinner();
-      _this._spinner.start();
-
-      return _this.aws.request('S3', 'listBuckets', {}, _this.evt.options.stage, _this.evt.options.region)
-        .bind(_this)
-        .then(function(data) {
-          data.Buckets.forEach(function(bucket) {
-            if (bucket.Name === _this.bucketName) {
-              _this.bucketExists = true;
-              S.utils.sDebug(`Bucket ${_this.bucketName} already exists`);
-            }
-          });
-        })
-        .then(function(){
-          if (!_this.bucketExists) return BbPromise.resolve();
-
-          S.utils.sDebug(`Listing objects in bucket ${_this.bucketName}...`);
-
-          let params = {
-            Bucket: _this.bucketName
-          };
-          return _this.aws.request('S3', 'listObjects', params, _this.evt.options.stage, _this.evt.options.region)
-        })
-        .then(function(data){
-          if (!_this.bucketExists) return BbPromise.resolve();
-
-          S.utils.sDebug(`Deleting all objects from bucket ${_this.bucketName}...`);
-
-          if (!data.Contents[0]) {
-            return BbPromise.resolve();
-          } else {
-            let Objects = _.map(data.Contents, function (content) {
-              return _.pick(content, 'Key');
-            });
-
-            let params = {
-              Bucket: _this.bucketName,
-              Delete: { Objects: Objects }
-            };
-            return _this.aws.request('S3', 'deleteObjects', params, _this.evt.options.stage, _this.evt.options.region)
-          }})
-        .then(function(){
-          if (_this.bucketExists) return BbPromise.resolve();
-          S.utils.sDebug(`Creating bucket ${_this.bucketName}...`);
-
-          let params = {
-            Bucket: _this.bucketName
-          };
-          return _this.aws.request('S3', 'createBucket', params, _this.evt.options.stage, _this.evt.options.region)
-        })
-        .then(function(){
-
-          S.utils.sDebug(`Configuring website bucket ${_this.bucketName}...`);
-
-          let params = {
-            Bucket: _this.bucketName,
-            WebsiteConfiguration: {
-              IndexDocument: { Suffix: 'index.html' },
-              ErrorDocument: { Key: 'error.html' }
-            }
-          };
-          return _this.aws.request('S3', 'putBucketWebsite', params, _this.evt.options.stage, _this.evt.options.region)
-        })
-        .then(function(){
-
-          S.utils.sDebug(`Configuring policy for bucket ${_this.bucketName}...`);
-
-          let policy = {
-            Version: "2008-10-17",
-            Id: "Policy1392681112290",
-            Statement: [
-              {
-                Sid: "Stmt1392681101677",
-                Effect: "Allow",
-                Principal: {
-                  AWS: "*"
-                },
-                Action: "s3:GetObject",
-                Resource: "arn:aws:s3:::" + _this.bucketName + '/*'
-              }
-            ]
-          };
-
-          let params = {
-            Bucket: _this.bucketName,
-            Policy: JSON.stringify(policy)
-          };
-          return _this.aws.request('S3', 'putBucketPolicy', params, _this.evt.options.stage, _this.evt.options.region)
-        })
-        .then(function(){
-          return _this._uploadDirectory(_this.clientPath)
-        });
-    }
-
-    _uploadDirectory(directoryPath) {
-      let _this         = this,
-        readDirectory = _.partial(fs.readdir, directoryPath);
-
-      async.waterfall([readDirectory, function (files) {
-        files = _.map(files, function(file) {
-          return path.join(directoryPath, file);
-        });
-
-        async.each(files, function(path) {
-          fs.stat(path, _.bind(function (err, stats) {
-
-            return stats.isDirectory()
-              ? _this._uploadDirectory(path)
-              : _this._uploadFile(path);
-          }, _this));
-        });
-      }]);
-
-    }
-
-    _uploadFile(filePath) {
-      let _this      = this,
-          fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace('\\', '/');
-
-      S.utils.sDebug(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
-
-      fs.readFile(filePath, function(err, fileBuffer) {
-
-        let params = {
-          Bucket: _this.bucketName,
-          Key: fileKey,
-          Body: fileBuffer,
-          ContentType: mime.lookup(filePath)
-        };
-
-        // TODO: remove browser caching
-        return _this.aws.request('S3', 'putObject', params, _this.evt.options.stage, _this.evt.options.region)
-      });
-
-    }
-
-  }
-  return ClientDeploy;
-};

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ class Client {
 
   _uploadFile(filePath) {
     let _this      = this,
-        fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace('\\', '/');
+        fileKey    = filePath.replace(_this.clientPath, '').substr(1).replace(/\\/g, '/');
 
     this.serverless.cli.log(`Uploading file ${fileKey} to bucket ${_this.bucketName}...`);
 

--- a/index.js
+++ b/index.js
@@ -48,9 +48,13 @@ class Client {
     const Utils = this.serverless.utils;
     const Error = this.serverless.classes.Error;
 
+    const _dist = 
+      (this.serverless.service.custom && this.serverless.service.custom.client) ? 
+        this.serverless.service.custom.client.distributionFolder :
+        "dist";
 
-    if (!Utils.dirExistsSync(path.join(this.serverless.config.servicePath, 'client', 'dist'))) {
-      return BbPromise.reject(new Error('Could not find "client/dist" folder in your project root.'));
+    if (!Utils.dirExistsSync(path.join(this.serverless.config.servicePath, 'client', _dist))) {
+      return BbPromise.reject(new Error('Could not find "client/' + _dist + ' folder in your project root.'));
     }
 
     if (!this.serverless.service.custom ||
@@ -60,7 +64,7 @@ class Client {
     }
 
     this.bucketName = this.serverless.service.custom.client.bucketName;
-    this.clientPath = path.join(this.serverless.config.servicePath, 'client', 'dist');
+    this.clientPath = path.join(this.serverless.config.servicePath, 'client', _dist);
 
     return BbPromise.resolve();
   }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const async        = require('async');
 const _            = require('lodash');
 const mime         = require('mime');
 const fs           = require('fs');
+const AWS = require('serverless/lib/plugins/aws');
 
 class Client {
   constructor(serverless, options){
@@ -36,16 +37,17 @@ class Client {
         this.serverless.cli.log(this.commands.client.usage);
       },
 
-      'client:deploy:deploy': this._prompt(),
+      'client:deploy:deploy': this._prompt.bind(this),
     };
   }
 
   _prompt() {
-    this._validateAndPrepare();
+    this._validateAndPrepare()
+      .then(this._processDeployment.bind(this));
   }
 
   _validateAndPrepare() {
-    const Utils = new this.serverless.classes.Utils(this.serverless);
+    const Utils = this.serverless.utils;
     const Error = this.serverless.classes.Error;
 
 
@@ -53,34 +55,166 @@ class Client {
       return BbPromise.reject(new Error('Could not find "client/dist" folder in your project root.'));
     }
 
-    // validate stage: make sure stage exists
-    if (!S.getProject().validateStageExists(_this.evt.options.stage)) {
-      return BbPromise.reject(new SError('Stage ' + _this.evt.options.stage + ' does not exist in your project', SError.errorCodes.UNKNOWN));
+    const stage = this.serverless.service.getStage(this.options.stage);
+    const region = this.serverless.service.getRegionInStage(this.options.stage, this.options.region);
+    
+    if (!this.serverless.service.custom.client || !this.serverless.service.custom.client.bucketName) {
+      return BbPromise.reject(new Error('Please specify a bucket name for the client in s-project.json'));
     }
 
-    // make sure region exists in stage
-    if (!S.getProject().validateRegionExists(_this.evt.options.stage, _this.evt.options.region)) {
-      return BbPromise.reject(new SError('Region "' + _this.evt.options.region + '" does not exist in stage "' + _this.evt.options.stage + '"'));
-    }
-
-    _this.project    = S.getProject();
-    _this.aws        = S.getProvider('aws');
-
-    let populatedProject = _this.project.toObjectPopulated({stage: _this.evt.options.stage, region: _this.evt.options.region});
-
-    if (!populatedProject.custom.client || !populatedProject.custom.client.bucketName) {
-      return BbPromise.reject(new SError('Please specify a bucket name for the client in s-project.json'));
-    }
-
-    _this.bucketName = populatedProject.custom.client.bucketName;
-    _this.clientPath = path.join(_this.project.getRootPath(), 'client', 'dist');
+    this.bucketName = this.serverless.service.custom.client.bucketName;
+    this.clientPath = path.join(this.serverless.config.servicePath, 'client', 'dist');
 
     return BbPromise.resolve();
   }
 
+ 
+  _processDeployment() {
+    const SDK = new AWS(this.serverless);    
+    this.serverless.cli.log('Deploying client to stage "' + this.options.stage + '" in region "' + this.options.region + '"...');
+
+
+    function listBuckets(data) {
+      data.Buckets.forEach(function(bucket) {
+        if (bucket.Name === this.bucketName) {
+          this.bucketExists = true;
+          this.serverless.cli.log(`Bucket ${this.bucketName} already exists`);
+        }
+      });
+    }
+
+    function listObjectsInBucket() {
+      if (!this.bucketExists) return BbPromise.resolve();
+
+      this.serverless.cli.log(`Listing objects in bucket ${this.bucketName}...`);
+
+      let params = {
+        Bucket: this.bucketName
+      };
+      return SDK.request('S3', 'listObjects', params, this.options.stage, this.options.region);
+    }
+
+    function deleteObjectsFromBucket(data) {
+      if (!this.bucketExists) return BbPromise.resolve();
+
+      this.serverless.cli.log(`Deleting all objects from bucket ${this.bucketName}...`);
+
+      if (!data.Contents[0]) {
+        return BbPromise.resolve();
+      } else {
+        let Objects = _.map(data.Contents, function (content) {
+          return _.pick(content, 'Key');
+        });
+
+        let params = {
+          Bucket: this.bucketName,
+          Delete: { Objects: Objects }
+        };
+        
+        return _SDK.request('S3', 'deleteObjects', params, _this.options.stage, _this.options.region)
+      }
+    }
+
+    function createBucket() {
+      if (this.bucketExists) return BbPromise.resolve();
+      this.serverless.cli.log(`Creating bucket ${this.bucketName}...`);
+
+      let params = {
+        Bucket: this.bucketName
+      };
+      
+      return SDK.request('S3', 'createBucket', params, this.options.stage, this.options.region)
+    }
+
+    function configureBucket() {
+      this.serverless.cli.log(`Configuring website bucket ${this.bucketName}...`);
+
+      let params = {
+        Bucket: this.bucketName,
+        WebsiteConfiguration: {
+          IndexDocument: { Suffix: 'index.html' },
+          ErrorDocument: { Key: 'error.html' }
+        }
+      };
+      
+      return SDK.request('S3', 'putBucketWebsite', params, this.options.stage, this.options.region)
+    }
+
+    function configurePolicyForBucket(){
+      this.serverless.cli.log(`Configuring policy for bucket ${this.bucketName}...`);
+
+      let policy = {
+        Version: "2008-10-17",
+        Id: "Policy1392681112290",
+        Statement: [
+          {
+            Sid: "Stmt1392681101677",
+            Effect: "Allow",
+            Principal: {
+              AWS: "*"
+            },
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::" + this.bucketName + '/*'
+          }
+        ]
+      };
+
+      let params = {
+        Bucket: this.bucketName,
+        Policy: JSON.stringify(policy)
+      };
+      
+      return SDK.request('S3', 'putBucketPolicy', params, this.options.stage, this.evt.options.region)
+    }
+ 
+    return SDK.request('S3', 'listBuckets', {}, this.options.stage, this.options.region)
+      .bind(this)
+      .then(listBuckets)
+      .then(listObjectsInBucket)
+      .then(deleteObjectsFromBucket)
+      .then(createBucket)
+      .then(configureBucket)
+      .then(configurePolicyForBucket)
+      .then(function(){
+        return this._uploadDirectory(this.clientPath)
+      });
+  }
+
+  _uploadDirectory(directoryPath) {
+    let _this         = this,
+        readDirectory = _.partial(fs.readdir, directoryPath);
+
+    async.waterfall([readDirectory, function (files) {
+      files = _.map(files, function(file) {
+        return path.join(directoryPath, file);
+      });
+
+      async.each(files, function(path) {
+        fs.stat(path, _.bind(function (err, stats) {
+
+          return stats.isDirectory()
+            ? _this._uploadDirectory(path)
+            : _this._uploadFile(path);
+        }, _this));
+      });
+    }]);
+
+  }  
+
 }
 
 module.exports = Client;
+
+
+
+
+
+
+
+
+
+
+
 
 const cool =  function(S) {
   const path     = require('path'),

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ class Client {
     this.commands = {
       client: {
         usage: 'Generate and deploy clients',
+        lifecycleEvents:[
+          'client',
+          'deploy'
+        ],
         commands: {
           deploy: {
             usage: 'Deploy serverless client code',
@@ -21,19 +25,19 @@ class Client {
 
 
     this.hooks = {
-      'client': () => {
+      'client:client': () => {
         console.log('lol do some shit');
       },
-      
-      'client:deploy': () => {
-        console.log('deploying client');
-      },
+
+      'client:deploy:deploy': () => {
+        console.log('deploying client lol');
+      },      
     };
   }
 
 }
 
-module.exports = Cool;
+module.exports = Client;
 
 const cool =  function(S) {
   const path     = require('path'),

--- a/index.js
+++ b/index.js
@@ -38,13 +38,11 @@ class Client {
         this.serverless.cli.log(this.commands.client.usage);
       },
 
-      'client:deploy:deploy': this._prompt.bind(this),
+      'client:deploy:deploy': () => {
+        this._validateAndPrepare()
+          .then(this._processDeployment.bind(this));     
+      }
     };
-  }
-
-  _prompt() {
-    this._validateAndPrepare()
-      .then(this._processDeployment.bind(this));
   }
 
   _validateAndPrepare() {
@@ -59,8 +57,10 @@ class Client {
     const stage = this.serverless.service.getStage(this.options.stage);
     const region = this.serverless.service.getRegionInStage(this.options.stage, this.options.region);
     
-    if (!this.serverless.service.custom.client || !this.serverless.service.custom.client.bucketName) {
-      return BbPromise.reject(new Error('Please specify a bucket name for the client in s-project.json'));
+    if (!this.serverless.service.custom ||
+        !this.serverless.service.custom.client ||
+        !this.serverless.service.custom.client.bucketName) {
+      return BbPromise.reject(new Error('Please specify a bucket name for the client in serverless.yml.'));
     }
 
     this.bucketName = this.serverless.service.custom.client.bucketName;
@@ -111,7 +111,7 @@ class Client {
           Delete: { Objects: Objects }
         };
         
-        return _this.SDK.request('S3', 'deleteObjects', params, _this.options.stage, _this.options.region)
+        return this.SDK.request('S3', 'deleteObjects', params, this.options.stage, this.options.region);
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -50,10 +50,7 @@ class Client {
     const Utils = this.serverless.utils;
     const Error = this.serverless.classes.Error;
 
-    const _dist = 
-      (this.serverless.service.custom && this.serverless.service.custom.client) ? 
-        this.serverless.service.custom.client.distributionFolder :
-        "dist";
+    const _dist = _.get(this.serverless, 'service.custom.client.distributionFolder', 'dist');
 
     if (!Utils.dirExistsSync(path.join(this.serverless.config.servicePath, 'client', _dist))) {
       return BbPromise.reject(new Error('Could not find "client/' + _dist + ' folder in your project root.'));

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const async        = require('async');
 const _            = require('lodash');
 const mime         = require('mime');
 const fs           = require('fs');
-const AWS = require('serverless/lib/plugins/aws');
 
 class Client {
   constructor(serverless, options){
     this.serverless = serverless;
-    this.SDK = new AWS(this.serverless);
+    this.provider = 'aws';
+    this.aws = this.serverless.getProvider(this.provider);
     
     this.commands = {
       client: {
@@ -87,7 +87,7 @@ class Client {
       let params = {
         Bucket: this.bucketName
       };
-      return this.SDK.request('S3', 'listObjects', params, this.serverless.service.provider.stage, this.serverless.service.provider.region);
+      return this.aws.request('S3', 'listObjects', params, this.serverless.service.provider.stage, this.serverless.service.provider.region);
     }
 
     function deleteObjectsFromBucket(data) {
@@ -107,7 +107,7 @@ class Client {
           Delete: { Objects: Objects }
         };
         
-        return this.SDK.request('S3', 'deleteObjects', params, this.serverless.service.provider.stage, this.serverless.service.provider.region);
+        return this.aws.request('S3', 'deleteObjects', params, this.serverless.service.provider.stage, this.serverless.service.provider.region);
       }
     }
 
@@ -119,7 +119,7 @@ class Client {
         Bucket: this.bucketName
       };
       
-      return this.SDK.request('S3', 'createBucket', params, this.serverless.service.provider.stage, this.serverless.service.provider.region)
+      return this.aws.request('S3', 'createBucket', params, this.serverless.service.provider.stage, this.serverless.service.provider.region)
     }
 
     function configureBucket() {
@@ -133,7 +133,7 @@ class Client {
         }
       };
       
-      return this.SDK.request('S3', 'putBucketWebsite', params, this.serverless.service.provider.stage, this.serverless.service.provider.region)
+      return this.aws.request('S3', 'putBucketWebsite', params, this.serverless.service.provider.stage, this.serverless.service.provider.region)
     }
 
     function configurePolicyForBucket(){
@@ -160,10 +160,10 @@ class Client {
         Policy: JSON.stringify(policy)
       };
       
-      return this.SDK.request('S3', 'putBucketPolicy', params, this.serverless.service.provider.stage, this.serverless.service.provider.region);
+      return this.aws.request('S3', 'putBucketPolicy', params, this.serverless.service.provider.stage, this.serverless.service.provider.region);
     }
  
-    return this.SDK.request('S3', 'listBuckets', {}, this.serverless.service.provider.stage, this.serverless.service.provider.region)
+    return this.aws.request('S3', 'listBuckets', {}, this.serverless.service.provider.stage, this.serverless.service.provider.region)
       .bind(this)
       .then(listBuckets)
       .then(listObjectsInBucket)
@@ -212,7 +212,7 @@ class Client {
       };
 
       // TODO: remove browser caching
-      return _this.SDK.request('S3', 'putObject', params, _this.serverless.service.provider.stage, _this.serverless.service.provider.region);
+      return _this.aws.request('S3', 'putObject', params, _this.serverless.service.provider.stage, _this.serverless.service.provider.region);
     });
 
   }  

--- a/index.js
+++ b/index.js
@@ -1,6 +1,41 @@
 'use strict';
 
-module.exports = function(S) {
+class Client {
+  constructor(serverless, options){
+    this.serverless = serverless;
+    this.options = options;
+    
+    this.commands = {
+      client: {
+        usage: 'Generate and deploy clients',
+        commands: {
+          deploy: {
+            usage: 'Deploy serverless client code',
+            lifecycleEvents:[
+              'deploy'
+            ]
+          }
+        }
+      }
+    };
+
+
+    this.hooks = {
+      'client': () => {
+        console.log('lol do some shit');
+      },
+      
+      'client:deploy': () => {
+        console.log('deploying client');
+      },
+    };
+  }
+
+}
+
+module.exports = Cool;
+
+const cool =  function(S) {
   const path     = require('path'),
     SError       = require(S.getServerlessPath('Error')),
     SCli         = require(S.getServerlessPath('utils/cli')),

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   },
   "homepage": "https://github.com/serverless/serverless-client-s3#readme",
   "dependencies": {
-    "mime": "^1.2.11",
     "async": "^1.5.2",
+    "bluebird": "^3.0.6",
     "lodash": "^4.2.1",
-    "bluebird": "^3.0.6"
+    "mime": "^1.2.11",
+    "serverless": "^1.0.0-beta.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
   "homepage": "https://github.com/serverless/serverless-client-s3#readme",
   "dependencies": {
     "async": "^1.5.2",
+    "aws-sdk": "^2.7.20",
     "bluebird": "^3.0.6",
     "lodash": "^4.2.1",
     "mime": "^1.2.11",
-    "serverless": "^1.0.0-beta.2"
+    "serverless": "^1.4.0"
   }
 }


### PR DESCRIPTION
This is my attempt to port the existing functionality to  the `1.0.0-beta` plugin architecture. You can use this to push `/dist` directory to an s3 bucket

This is currently tightly coupled to the AWS provider. Not 100% sure how to improve that. Looking at the core plugins, it looks like they have 'base plugins' that define the commands  and lifecycleEvents. Then they have provider-specific commands that extend. I can follow that pattern here.

The 0.5 version of serverless and this plugin had features that i'm not clear on how to reproduce with 1.0.0 or if they are still a 'serverless pattern'

The CLi spinner:
https://github.com/serverless/serverless-client-s3/blob/master/index.js#L127-L128

The CLI prompt to enter stage and region
https://github.com/serverless/serverless-client-s3/blob/master/index.js#L72-L82
