### PR TITLE
Add Cache-Control capabilities to s3 deployment

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,17 +247,10 @@ module.exports = function(S) {
           ContentType: mime.lookup(filePath)
         };
         
-        if (
-          _this.CacheControl && (
-            !_this.CacheControl.regex ||
-            filePath.match(new RegExp(_this.CacheControl.regex, "i")
-          )
-        ) {
+        if (_this.CacheControl && (!(_this.CacheControl.regex) || (filePath.match(new RegExp(_this.CacheControl.regex, "i"))))) {
           params.CacheControl = _this.CacheControl.value;
-        }
+        };
 
-
-        // TODO: remove browser caching
         return _this.aws.request('S3', 'putObject', params, _this.evt.options.stage, _this.evt.options.region)
       });
 

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ module.exports = function(S) {
       }
 
       _this.bucketName = populatedProject.custom.client.bucketName;
+      _this.CacheControl = populatedProject.custom.client.CacheControl;
       _this.clientPath = path.join(_this.project.getRootPath(), 'client', 'dist');
 
       return BbPromise.resolve();
@@ -245,6 +246,16 @@ module.exports = function(S) {
           Body: fileBuffer,
           ContentType: mime.lookup(filePath)
         };
+        
+        if (
+          _this.CacheControl && (
+            !_this.CacheControl.regex ||
+            filePath.match(new RegExp(_this.CacheControl.regex, "i")
+          )
+        ) {
+          params.CacheControl = _this.CacheControl.value;
+        }
+
 
         // TODO: remove browser caching
         return _this.aws.request('S3', 'putObject', params, _this.evt.options.stage, _this.evt.options.region)


### PR DESCRIPTION
Cache-Control headers can be provided to S3 elements in order to allow browser and CloudFront caching

http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html

In order to control this by file or for all of them I've created the possibility to give that custom param

Now we can do something like

```json
{
    "name": "yourProject",
    "custom": {	
      "client": {	
      "bucketName": "yourBucketName",
      "CacheControl": {
        "value": "max-age=300, s-maxage=300",
        "regex": ".*\\.(gif|jpe?g|png|js|svg|css)$"
      }
    },
    "plugins": [
     "serverless-client-s3"
    ]
}
```